### PR TITLE
Resolve UFP Plugin Conflict

### DIFF
--- a/octoprint_GcodeEditor/static/js/GcodeEditor.js
+++ b/octoprint_GcodeEditor/static/js/GcodeEditor.js
@@ -203,7 +203,7 @@ $(function() {
                                     {fileName: htmlEncode(typeof self.files.currentPath === "undefined" ||
                                     self.files.currentPath().length == 0 ? "" :
                                     "/" + self.files.currentPath() + "/") +
-                                    button.parent().parent().children("div").eq(0).html()}),
+                                    button.parent().parent().children("div.title").eq(0).html()}),
                                 function() {                                                            // onloadCallback
 
                                     setTimeout(function() {

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_GcodeEditor"
 plugin_name = "OctoPrint-GcodeEditor"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.6"
+plugin_version = "0.2.7"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
This change will resolve issues introduced by the UltimakerFormatPackage plugin where the file name was grabbing the html contents of the injected image rather than the title of the file.