### PR TITLE
Set __plugin_pythoncompat__ explicitly to allow plugin to run under Python3 in OctoPrint V1.4

### DIFF
--- a/octoprint_GcodeEditor/__init__.py
+++ b/octoprint_GcodeEditor/__init__.py
@@ -43,6 +43,10 @@ class GcodeEditorPlugin(octoprint.plugin.TemplatePlugin,
 
 __plugin_name__ = "GcodeEditor"
 
+# Starting with OctoPrint 1.4.0 OctoPrint will also support to run under Python 3 in addition to the deprecated
+# Python 2. New plugins should make sure to run under both versions for now.
+__plugin_pythoncompat__ = ">=2.7,<4" # python 2 and 3
+
 def __plugin_load__():
     global __plugin_implementation__
     __plugin_implementation__ = GcodeEditorPlugin()


### PR DESCRIPTION
OctoPrint 1.4.0 can run now under both Python 3 and (the deprecated) Python 2.

By default, pre-existing plugins are assumed to ONLY run under Python 2. So, to have them recognised as being able to run under Python 3, the __plugin_pythoncompat__ variable must be set explicitly, eg -

__plugin_pythoncompat__ = ">=2.7,<4"