### PR TITLE
Update to GcodeEditor.js to make the app compatible with Octoprint 1.8.1

### DIFF
--- a/octoprint_GcodeEditor/static/js/GcodeEditor.js
+++ b/octoprint_GcodeEditor/static/js/GcodeEditor.js
@@ -68,7 +68,7 @@ $(function() {
 
             var file = new Blob([gtext], { type: "text/plain" });
 
-            OctoPrint.files.upload("local", file, { filename: _selectedFilePath + fName });
+            OctoPrint.files.upload("local", file, { filename: fName, path: _selectedFilePath });
 
             $('#gcode_edit_dialog').modal('hide');
         });


### PR DESCRIPTION
Modified line 71 to fix the problem with file edits not saving.
Implementation of the recommendations found here https://github.com/ieatacid/OctoPrint-GcodeEditor/issues/28#issuecomment-931427588