### PR TITLE
Update to GcodeEditor.js to make it compatible with Octoprint 1.8.1

### DIFF
--- a/octoprint_GcodeEditor/static/js/GcodeEditor.js
+++ b/octoprint_GcodeEditor/static/js/GcodeEditor.js
@@ -68,7 +68,7 @@ $(function() {
 
             var file = new Blob([gtext], { type: "text/plain" });
 
-            OctoPrint.files.upload("local", file, { filename: _selectedFilePath + fName });
+            OctoPrint.files.upload("local", file, { filename: fName, path: _selectedFilePath });
 
             $('#gcode_edit_dialog').modal('hide');
         });
@@ -79,7 +79,7 @@ $(function() {
 
             var file = new Blob([gtext], { type: "text/plain" });
 
-            OctoPrint.files.upload("local", file, { filename: _selectedFilePath + fName });
+            OctoPrint.files.upload("local", file, { filename: fName, path: _selectedFilePath });
 
             $('#gcode_edit_dialog').modal('hide');
         });


### PR DESCRIPTION
This is an implementation of the solution found here https://github.com/ieatacid/OctoPrint-GcodeEditor/issues/28#issuecomment-931427588
I have discovered that the defective string is at both line 71 and line 81 so both were changed to hopefully fix the issue with the .gcode file edits not saving.